### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,6 @@
 name: Lint
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/eliperkins/eliperkins-blog/security/code-scanning/1](https://github.com/eliperkins/eliperkins-blog/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. Since this is a linting workflow that does not require write access, we will set `contents: read` as the minimal permission. This ensures that the workflow has only the permissions it needs to execute safely.

The changes will be made at the top of the workflow file, immediately after the `name` field.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
